### PR TITLE
[Fix] 채팅방 조회 문제 해결

### DIFF
--- a/backend/src/main/java/com/hot6/backend/chat/ChatController.java
+++ b/backend/src/main/java/com/hot6/backend/chat/ChatController.java
@@ -93,9 +93,10 @@ public class ChatController {
     @Operation(summary = "단일 채팅방의 정보 조회", description = "단일 채팅방의 정보를 조회합니다.(채팅방 이름, 해시 태그)")
     @GetMapping("/chatroom/{chatRoomIdx}")
     public ResponseEntity<BaseResponse<ChatDto.ChatRoomDetailInfo>> getChatRoomInfo(
+            @AuthenticationPrincipal User user,
             @PathVariable Long chatRoomIdx
     ) {
-        return ResponseEntity.ok(new BaseResponse(BaseResponseStatus.SUCCESS,chatRoomService.getChatRoomInfo(chatRoomIdx)));
+        return ResponseEntity.ok(new BaseResponse(BaseResponseStatus.SUCCESS,chatRoomService.getChatRoomInfo(chatRoomIdx,user.getIdx())));
     }
 
     @Operation(summary = "채팅방 정보 조회 - 현재 참여한 유저", description = "현재 채팅방에 참여하고 있는 유저의 목록을 조회합니다.")

--- a/backend/src/main/java/com/hot6/backend/chat/model/ChatDto.java
+++ b/backend/src/main/java/com/hot6/backend/chat/model/ChatDto.java
@@ -114,15 +114,22 @@ public class ChatDto {
         @Schema(description = "채팅방 해시태그", example = "[\"#햄스터\", \"#친구\"]")
         public List<String> hashtags;
 
+        @Schema(description = "채팅방 주인", example = "true")
+        public boolean isAdmin;
+
         @Schema(description = "채팅방 참여 인원수", example = "6")
         public int participants;
 
-        public static ChatRoomDetailInfo from(ChatRoom chatRoom) {
+        public static ChatRoomDetailInfo from(ChatRoom chatRoom,Long userIdx) {
             return ChatRoomDetailInfo.builder()
                     .idx(chatRoom.getIdx())
                     .title(chatRoom.getCTitle())
                     .participants(chatRoom.getParticipants().size())
                     .hashtags(chatRoom.getHashtags().stream().map(ChatRoomHashtag::getCTag).collect(Collectors.toList()))
+                    .isAdmin(
+                            chatRoom.getParticipants().stream()
+                                    .anyMatch(p -> p.getUser().getIdx().equals(userIdx) && p.getIsAdmin())
+                    )
                     .build();
         }
     }

--- a/backend/src/main/java/com/hot6/backend/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/hot6/backend/chat/service/ChatRoomService.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -83,11 +84,11 @@ public class ChatRoomService {
         return chatMessageService.findChatMessages(chatRoomParticipant);
     }
 
-    public ChatDto.ChatRoomDetailInfo getChatRoomInfo(Long chatRoomIdx) {
+    public ChatDto.ChatRoomDetailInfo getChatRoomInfo(Long chatRoomIdx,Long userIdx) {
         ChatRoom chatRoom = chatRoomRepository.findWithParticipantsAndHashtagsById(chatRoomIdx)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.CHAT_ROOM_NOT_FOUND));
 
-        return ChatDto.ChatRoomDetailInfo.from(chatRoom);
+        return ChatDto.ChatRoomDetailInfo.from(chatRoom,userIdx);
     }
 
     @Transactional


### PR DESCRIPTION
채팅방을 조회할 때, 채팅방 참여 유저의 메타 데이터를 불러올 때 오류
원인은 채팅방을 처음 만들고 나서 채팅방 참여 유저의 메타데이터를 만들었어야 했는데, 그러지 않아서 null 로 들어갔음. 그래서 채팅방을 처음 만들때, 채팅을 하나 만들고, 이 채팅을 채팅방 참여 유저에 연결!